### PR TITLE
Simplify `IsFormAllocateReplacedByEF` and `RehookFormAllocate`

### DIFF
--- a/Code/client/Games/Memory.h
+++ b/Code/client/Games/Memory.h
@@ -5,9 +5,6 @@ struct Memory
     [[nodiscard]] static void* Allocate(size_t aSize) noexcept;
     static void Free(void* apData) noexcept;
 
-    static bool IsFormAllocateReplacedByEF() noexcept;
-    static bool RehookMemoryFunctions() noexcept;
-
     template <class T> static T* Allocate() noexcept
     {
         auto pMemory = static_cast<T*>(Allocate(sizeof(T)));

--- a/Code/client/Services/Debug/DebugService.cpp
+++ b/Code/client/Services/Debug/DebugService.cpp
@@ -419,7 +419,7 @@ void DebugService::ArrangeGameWindows(HWND aThisWindow) noexcept
     if (!shouldArrangeWindows)
         return; // Too little room for that
 
-    SetWindowPos(GetConsoleWindow(), nullptr, 0, gameWindowHeight, 0, 0, SWP_NOSIZE | SWP_NOACTIVATE);
+    SetWindowPos(GetConsoleWindow(), nullptr, 0, gameWindowHeight, 0, 0, SWP_NOSIZE);
 
     CreateMutexA(0, FALSE, "SkyrimTogetherWindowMutex");
     if (GetLastError() == ERROR_ALREADY_EXISTS)

--- a/Code/client/Services/Debug/DebugService.cpp
+++ b/Code/client/Services/Debug/DebugService.cpp
@@ -419,7 +419,7 @@ void DebugService::ArrangeGameWindows(HWND aThisWindow) noexcept
     if (!shouldArrangeWindows)
         return; // Too little room for that
 
-    SetWindowPos(GetConsoleWindow(), nullptr, 0, gameWindowHeight, 0, 0, SWP_NOSIZE);
+    SetWindowPos(GetConsoleWindow(), nullptr, 0, gameWindowHeight, 0, 0, SWP_NOSIZE | SWP_NOACTIVATE);
 
     CreateMutexA(0, FALSE, "SkyrimTogetherWindowMutex");
     if (GetLastError() == ERROR_ALREADY_EXISTS)


### PR DESCRIPTION
Simplified functions, covered both EF 6.2 and EF 7.x

Suggestion: remove EF from the greylist completely. Or too risky?